### PR TITLE
Update for supporting various kernel versions

### DIFF
--- a/package/host/src/nrc/mac80211-ext.c
+++ b/package/host/src/nrc/mac80211-ext.c
@@ -149,7 +149,9 @@ struct sk_buff *ieee80211_deauth_get(struct ieee80211_hw *hw,
 			status = IEEE80211_SKB_RXCB(skb);
 			status->flag |= RX_FLAG_DECRYPTED;
 			status->flag |= RX_FLAG_MMIC_STRIPPED;
+#if KERNEL_VERSION(4, 3, 0) <= NRC_TARGET_KERNEL_VERSION
 			status->flag |= RX_FLAG_PN_VALIDATED;
+#endif
 		}
 	} else {
 		deauth->u.deauth.reason_code = reason;

--- a/package/host/src/nrc/nrc-build-config.h
+++ b/package/host/src/nrc/nrc-build-config.h
@@ -32,9 +32,9 @@
 
 /*
  * README This is a temporary feature.
- * Use only NRC7392
+ * Use only NRC7392 & NRC4791
  */
-#define CONFIG_CHECK_READY
+/* #define CONFIG_CHECK_READY */
 
 /*
  * README This is a temporary feature.

--- a/package/host/src/nrc/nrc-debug.h
+++ b/package/host/src/nrc/nrc-debug.h
@@ -47,15 +47,15 @@ enum LOOPBACK_MODE {
 
 struct lb_time_info {
 	int _i;
-	ktime_t _txt;
-	ktime_t _rxt;
+	s64 _txt;
+	s64 _rxt;
 };
 
 extern unsigned long nrc_debug_mask;
-extern ktime_t tx_time_first;
-extern ktime_t tx_time_last;
-extern ktime_t rcv_time_first;
-extern ktime_t rcv_time_last;
+extern s64 tx_time_first;
+extern s64 tx_time_last;
+extern s64 rcv_time_first;
+extern s64 rcv_time_last;
 extern u32 arv_time_first;
 extern u32 arv_time_last;
 extern struct lb_time_info *time_info_array;

--- a/package/host/src/nrc/nrc-init.c
+++ b/package/host/src/nrc/nrc-init.c
@@ -683,4 +683,6 @@ module_exit(nrc_exit);
 MODULE_AUTHOR("Newracom, Inc.(http://www.newracom.com)");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Newracom 802.11 driver");
+#if KERNEL_VERSION(5, 12, 0) > NRC_TARGET_KERNEL_VERSION
 MODULE_SUPPORTED_DEVICE("Newracom 802.11 devices");
+#endif

--- a/package/host/src/nrc/nrc-mac80211.c
+++ b/package/host/src/nrc/nrc-mac80211.c
@@ -2600,8 +2600,8 @@ int nrc_mac_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan)
 	struct nrc_txq *ntxq;
 	struct wim_pm_param *p;
 
-	nrc_ps_dbg("[%s,L%d] any:%d patterns(0x%08x) n_patterns(%d)\n", __func__, __LINE__, 
-			wowlan->any, (int)wowlan->patterns, wowlan->n_patterns);
+	nrc_ps_dbg("[%s,L%d] any:%d patterns(%p) n_patterns(%d)\n", __func__, __LINE__, 
+			wowlan->any, wowlan->patterns, wowlan->n_patterns);
 
 	/*
 	 * If the target is already in deepsleep state(running uCode),
@@ -2666,8 +2666,12 @@ int nrc_mac_suspend(struct ieee80211_hw *hw, struct cfg80211_wowlan *wowlan)
 }
 #endif
 
+#if KERNEL_VERSION(4, 8, 0) <= NRC_TARGET_KERNEL_VERSION
 static u32 nrc_get_expected_throughput(struct ieee80211_hw *hw,
 		struct ieee80211_sta *sta)
+#else
+static u32 nrc_get_expected_throughput(struct ieee80211_sta *sta)
+#endif
 {
 	uint32_t tput = 0;
 

--- a/package/host/src/nrc/nrc-trx.c
+++ b/package/host/src/nrc/nrc-trx.c
@@ -473,10 +473,13 @@ static void nrc_mac_rx_h_status(struct nrc *nw, struct sk_buff *skb)
 	if (fh->flags.rx.iv_stripped)
 		status->flag |= RX_FLAG_IV_STRIPPED;
 
+#if ((KERNEL_VERSION(4, 4, 132) <= NRC_TARGET_KERNEL_VERSION) && (KERNEL_VERSION(4, 5, 0) > NRC_TARGET_KERNEL_VERSION)) ||\
+	(KERNEL_VERSION(4, 7, 0) <= NRC_TARGET_KERNEL_VERSION)
 	if(mh->frame_control & 0x0400)
 	{
 		status->flag |= RX_FLAG_ALLOW_SAME_PN;
 	}
+#endif
 
 	if (signal_monitor) {
 		//update snr and rssi only if signal monitor is enabled


### PR DESCRIPTION
We have tried to build the driver in various kernels.
(It has been checked from RPi branch rpi-4.1.y to rpi-5.15.y.)
There are some additional updates for kernel compatibilities.

(1) RX_FLAG_PN_VALIDATED from 4.3.0 or later (mac80211-ext.c)
(2) unsupport MODULE_SUPPORTED_DEVICE() from 5.12.0 (nrc-init.c)
(3) RX_FLAG_ALLOW_SAME_PN exist/not exist (nrc-trx.c)
(4) change type from ktime_t to s64 (nrc-debug.c)
(5) different argument of nrc_get_expected_throughput (nrc-mac80211.c)